### PR TITLE
Remove Mutex around SessionContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,6 @@ dependencies = [
  "datafusion",
  "futures",
  "pgwire",
- "tokio",
 ]
 
 [[package]]

--- a/datafusion-postgres/Cargo.toml
+++ b/datafusion-postgres/Cargo.toml
@@ -20,5 +20,4 @@ pgwire = { workspace = true }
 datafusion = { workspace = true }
 futures = "0.3"
 async-trait = "0.1"
-tokio = { workspace = true, features = ["sync"] }
 chrono = { version = "0.4", features = ["std"] }


### PR DESCRIPTION
I think every use of `SessionContext` can work with a reference.