### PR TITLE
Fix parameter type ordering

### DIFF
--- a/datafusion-postgres/src/handlers.rs
+++ b/datafusion-postgres/src/handlers.rs
@@ -201,13 +201,11 @@ impl ExtendedQueryHandler for DfSessionService {
     }
 }
 
-fn ordered_param_types<'a>(
-    types: &'a HashMap<String, Option<DataType>>,
-) -> Vec<Option<&'a DataType>> {
+fn ordered_param_types(types: &HashMap<String, Option<DataType>>) -> Vec<Option<&DataType>> {
     // Datafusion stores the parameters as a map.  In our case, the keys will be
     // `$1`, `$2` etc.  The values will be the parameter types.
 
     let mut types = types.iter().collect::<Vec<_>>();
-    types.sort_by(|a, b| a.0.cmp(&b.0));
+    types.sort_by(|a, b| a.0.cmp(b.0));
     types.into_iter().map(|pt| pt.1.as_ref()).collect()
 }


### PR DESCRIPTION
Until now, the parameter types were obtained by calling `.values()` on the HashSet of parameter types, but this leads to unpredicable ordering, causing queries to fail because their parameters were often transposed.

Instead, sort the parameter types by their names.  This should always work because in the postgresql case, the keys are '$1', '$2', etc.