### PR TITLE
Support Dictionary types as they're logically equivalent to their value types. Needed for delta-rs partition columns.

### DIFF
--- a/datafusion-postgres/src/datatypes.rs
+++ b/datafusion-postgres/src/datatypes.rs
@@ -765,12 +765,7 @@ where
         if let Some(ty) = pg_type_hint {
             Ok(ty.clone())
         } else if let Some(infer_type) = inferenced_type {
-            // If inferenced type is a dictionary, use the value type
-            let actual_type = match infer_type {
-                DataType::Dictionary(_, value_type) => value_type.as_ref(),
-                other_type => other_type,
-            };
-            into_pg_type(actual_type)
+            into_pg_type(infer_type)
         } else {
             Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "FATAL".to_string(),

--- a/datafusion-postgres/src/datatypes.rs
+++ b/datafusion-postgres/src/datatypes.rs
@@ -673,9 +673,7 @@ pub(crate) fn df_schema_to_pg_fields(
         .iter()
         .enumerate()
         .map(|(idx, f)| {
-            // Convert to PostgreSQL type using the unwrapped type
             let pg_type = into_pg_type(f.data_type())?;
-
             Ok(FieldInfo::new(
                 f.name().into(),
                 None,

--- a/datafusion-postgres/src/datatypes.rs
+++ b/datafusion-postgres/src/datatypes.rs
@@ -348,13 +348,7 @@ fn encode_value(
         },
 
         DataType::List(field) | DataType::FixedSizeList(field, _) | DataType::LargeList(field) => {
-            // Extract the inner type, handling dictionaries by getting the value type
-            let field_type = match field.data_type() {
-                DataType::Dictionary(_, value_type) => value_type.as_ref(),
-                data_type => data_type,
-            };
-
-            match field_type {
+            match field.data_type() {
                 DataType::Null => encoder.encode_field(&None::<i8>)?,
                 DataType::Boolean => encoder.encode_field(&get_bool_list_value(arr, idx))?,
                 DataType::Int8 => encoder.encode_field(&get_i8_list_value(arr, idx))?,

--- a/datafusion-postgres/src/datatypes.rs
+++ b/datafusion-postgres/src/datatypes.rs
@@ -679,14 +679,8 @@ pub(crate) fn df_schema_to_pg_fields(
         .iter()
         .enumerate()
         .map(|(idx, f)| {
-            // Get the actual data type, unwrapping any dictionary type
-            let data_type = match f.data_type() {
-                DataType::Dictionary(_, value_type) => value_type.as_ref(),
-                other_type => other_type,
-            };
-
             // Convert to PostgreSQL type using the unwrapped type
-            let pg_type = into_pg_type(data_type)?;
+            let pg_type = into_pg_type(f.data_type())?;
 
             Ok(FieldInfo::new(
                 f.name().into(),


### PR DESCRIPTION
Hi @sunng87, thanks for this really useful project you created.

At the moment, Dictionary types are not supported in datafusion-postgres. 
But they're important since projects like delta-rs represent partition columns as Dictionary types. Specifically `Dictionary<UInt16, Utf8>` for Utf8 columns.

So running a query via datafusion-postgres would result in an error such as:
```rust
UserError(
    ErrorInfo {
        severity: "ERROR",
        code: "XX000",
        message: "Unsupported Datatype Dictionary(UInt16, Utf8) and array DictionaryArray {
    keys: PrimitiveArray<UInt16>
    [
        0,
    ]
    values: StringArray
    [
        \"test_project\",
    ]
}",
    }
)
```

In the datafusion codebase: https://github.com/apache/datafusion/blob/main/datafusion/common/src/dfschema.rs#L665 

Dictionary types are treated as logically equal to their values:
```rust
(DataType::Dictionary(_, v1), DataType::Dictionary(_, v2)) => {
                v1.as_ref() == v2.as_ref()
            }
            (DataType::Dictionary(_, v1), othertype) => v1.as_ref() == othertype,
            (othertype, DataType::Dictionary(_, v1)) => v1.as_ref() == othertype,
```

I'm not very sure what the edge cases would be, i.e. what other Postgres types could be represented as a Dictionary type. I assume postgres hstore would be encoded as a Map and not a Dictionary.

In anycase, this PR resolves the error from parsing delta-rs partition columns through datafusion-postgres.


