### PR TITLE
feat: high-level serve function for `SessionContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "futures",
+ "getset",
  "log",
  "pgwire",
  "postgres-types",
@@ -1773,6 +1774,18 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2720,6 +2733,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/datafusion-postgres-cli/src/main.rs
+++ b/datafusion-postgres-cli/src/main.rs
@@ -1,13 +1,9 @@
-use std::sync::Arc;
-
 use datafusion::execution::options::{
     ArrowReadOptions, AvroReadOptions, CsvReadOptions, NdJsonReadOptions, ParquetReadOptions,
 };
 use datafusion::prelude::SessionContext;
-use datafusion_postgres::{DfSessionService, HandlerFactory}; // Assuming the crate name is `datafusion_postgres`
-use pgwire::tokio::process_socket;
+use datafusion_postgres::{serve, ServerOptions}; // Assuming the crate name is `datafusion_postgres`
 use structopt::StructOpt;
-use tokio::net::TcpListener;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -103,33 +99,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Loaded {} as table {}", table_path, table_name);
     }
 
-    // Get the first catalog name from the session context
-    let catalog_name = session_context
-        .catalog_names() // Fixed: Removed .catalog_list()
-        .first()
-        .cloned();
+    let server_options = ServerOptions {
+        host: opts.host.clone(),
+        port: opts.port,
+    };
 
-    // Create the handler factory with the session context and catalog name
-    let factory = Arc::new(HandlerFactory(Arc::new(DfSessionService::new(
-        session_context,
-        catalog_name,
-    ))));
+    serve(session_context, &server_options)
+        .await
+        .map_err(|e| format!("Failed to run server: {}", e))?;
 
-    // Bind to the specified host and port
-    let server_addr = format!("{}:{}", opts.host, opts.port);
-    let listener = TcpListener::bind(&server_addr).await?;
-    println!("Listening on {}", server_addr);
-
-    // Accept incoming connections
-    loop {
-        let (socket, addr) = listener.accept().await?;
-        let factory_ref = factory.clone();
-        println!("Accepted connection from {}", addr);
-
-        tokio::spawn(async move {
-            if let Err(e) = process_socket(socket, None, factory_ref).await {
-                eprintln!("Error processing socket: {}", e);
-            }
-        });
-    }
+    Ok(())
 }

--- a/datafusion-postgres-cli/src/main.rs
+++ b/datafusion-postgres-cli/src/main.rs
@@ -99,10 +99,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Loaded {} as table {}", table_path, table_name);
     }
 
-    let server_options = ServerOptions {
-        host: opts.host.clone(),
-        port: opts.port,
-    };
+    let server_options = ServerOptions::new()
+        .with_host(opts.host)
+        .with_port(opts.port);
 
     serve(session_context, &server_options)
         .await

--- a/datafusion-postgres/Cargo.toml
+++ b/datafusion-postgres/Cargo.toml
@@ -25,4 +25,4 @@ log = "0.4"
 pgwire = { workspace = true }
 postgres-types = "0.2"
 rust_decimal = { version = "1.37", features = ["db-postgres"] }
-tokio = { version = "1.45", features = ["sync"] }
+tokio = { version = "1.45", features = ["sync", "net"] }

--- a/datafusion-postgres/Cargo.toml
+++ b/datafusion-postgres/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1.10.1"
 chrono = { version = "0.4", features = ["std"] }
 datafusion = { workspace = true }
 futures = "0.3"
+getset = "0.1"
 log = "0.4"
 pgwire = { workspace = true }
 postgres-types = "0.2"

--- a/datafusion-postgres/src/lib.rs
+++ b/datafusion-postgres/src/lib.rs
@@ -8,12 +8,21 @@ pub use handlers::{DfSessionService, HandlerFactory, Parser};
 use std::sync::Arc;
 
 use datafusion::prelude::SessionContext;
+use getset::{Getters, Setters, WithSetters};
 use pgwire::tokio::process_socket;
 use tokio::net::TcpListener;
 
+#[derive(Getters, Setters, WithSetters)]
+#[getset(get = "pub", set = "pub", set_with = "pub")]
 pub struct ServerOptions {
-    pub host: String,
-    pub port: u16,
+    host: String,
+    port: u16,
+}
+
+impl ServerOptions {
+    pub fn new() -> ServerOptions {
+        ServerOptions::default()
+    }
 }
 
 impl Default for ServerOptions {

--- a/datafusion-postgres/src/lib.rs
+++ b/datafusion-postgres/src/lib.rs
@@ -4,3 +4,60 @@ mod handlers;
 mod information_schema;
 
 pub use handlers::{DfSessionService, HandlerFactory, Parser};
+
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+use pgwire::tokio::process_socket;
+use tokio::net::TcpListener;
+
+pub struct ServerOptions {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for ServerOptions {
+    fn default() -> Self {
+        ServerOptions {
+            host: "127.0.0.1".to_string(),
+            port: 5432,
+        }
+    }
+}
+
+/// Serve the Datafusion `SessionContext` with Postgres protocol.
+pub async fn serve(
+    session_context: SessionContext,
+    opts: &ServerOptions,
+) -> Result<(), std::io::Error> {
+    // Get the first catalog name from the session context
+    let catalog_name = session_context
+        .catalog_names() // Fixed: Removed .catalog_list()
+        .first()
+        .cloned();
+
+    // Create the handler factory with the session context and catalog name
+    let factory = Arc::new(HandlerFactory(Arc::new(DfSessionService::new(
+        session_context,
+        catalog_name,
+    ))));
+
+    // Bind to the specified host and port
+    let server_addr = format!("{}:{}", opts.host, opts.port);
+    let listener = TcpListener::bind(&server_addr).await?;
+    println!("Listening on {}", server_addr);
+
+    // Accept incoming connections
+    loop {
+        if let Ok((socket, addr)) = listener.accept().await {
+            let factory_ref = factory.clone();
+            println!("Accepted connection from {}", addr);
+
+            tokio::spawn(async move {
+                if let Err(e) = process_socket(socket, None, factory_ref).await {
+                    eprintln!("Error processing socket: {}", e);
+                }
+            });
+        };
+    }
+}


### PR DESCRIPTION
This patch adds a shortcut function to start a server from `SessionContext`